### PR TITLE
Update cache action to v4 from v3

### DIFF
--- a/actions/build/action.yml
+++ b/actions/build/action.yml
@@ -71,9 +71,9 @@ runs:
 
     - name: Load cache
       if: ${{ steps.check_cache.outputs.found != 'true' }}
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
-        key: ${{ inputs.cache_key }}-${{github.run_id }}
+        key: ${{ inputs.cache_key }}-${{ github.run_id }}
         path: ${{ inputs.cache_path }}
         restore-keys: ${{ inputs.cache_key }}
 


### PR DESCRIPTION
Just a small change to alleviate GitHub complaining about the node version: `The following actions use a deprecated Node.js version and will be forced to run on node20: actions/cache@v3.`.

Should be no change to the functionality of the action itself.