### PR TITLE
Add Typescript type declaration file to conveyor-control; Missing error message

### DIFF
--- a/electron/conveyor-control/index.d.ts
+++ b/electron/conveyor-control/index.d.ts
@@ -36,7 +36,8 @@ declare module '@hydraulic/conveyor-control' {
 
         /**
          * Create an OnlineUpdater.
-         * @param {string} updateSiteURL - The base URL of the update site (same as `app.site.base-url` in your Conveyor config).
+         * @param {string} updateSiteURL - The base URL of the update 
+         * site (same as `app.site.base-url` in your Conveyor config).
          */
         constructor(updateSiteURL: string);
 
@@ -60,7 +61,8 @@ declare module '@hydraulic/conveyor-control' {
 
         /**
          * Get the current version from the repository.
-         * @returns {Promise<Version>} A promise that resolves with the current version from the repository.
+         * @returns {Promise<Version>} A promise that resolves with the 
+         * current version from the repository.
          */
         getCurrentVersionFromRepository(): Promise<Version>;
 

--- a/electron/conveyor-control/index.d.ts
+++ b/electron/conveyor-control/index.d.ts
@@ -24,7 +24,8 @@ declare module '@hydraulic/conveyor-control' {
     }
 
     /**
-     * Object that lets you interact with Conveyor. Not all platforms are supported; call `canTriggerUpdateCheckUI` first.
+     * Object that lets you interact with Conveyor. 
+     * Not all platforms are supported; call `canTriggerUpdateCheckUI` first.
      */
     export class OnlineUpdater {
         isWindows: boolean;
@@ -40,14 +41,17 @@ declare module '@hydraulic/conveyor-control' {
         constructor(updateSiteURL: string);
 
         /**
-         * Get the current version of the application by reading the `metadata.properties` file in your update site.
+         * Get the current version of the application by reading 
+         * the `metadata.properties` file in your update site.
          * @returns {Version} The current version.
          */
         getCurrentVersion(): Version;
 
         /**
-         * Triggers the update process. If there is an update available it will be applied automatically (on Windows) or prompt the user
-         * (on macOS), and the app will be restarted if the update is applied. You should ensure you're in a position to restart without the
+         * Triggers the update process. If there is an update available 
+         * it will be applied automatically (on Windows) or prompt the user
+         * (on macOS), and the app will be restarted if the update is applied. 
+         * You should ensure you're in a position to restart without the
          * user losing data before calling this.
          *
          * @throws {Error} If update checks are unavailable.

--- a/electron/conveyor-control/index.d.ts
+++ b/electron/conveyor-control/index.d.ts
@@ -1,88 +1,94 @@
 /**
  * Type declarations for Electron applications built with Typescript.
  */
-declare module '@hydraulic/conveyor-control' {
+declare module "@hydraulic/conveyor-control" {
     export class Version {
-        version: string;
-        revision: number;
-
-        constructor(version: string, revision?: number);
-
-        compareTo(other: Version): number;
-
-        toString(): string;
-
-        static ComparableVersion: {
-            new (version: string): {
-                value: string;
-                items: number[];
-                parseVersion(version: string): number[];
-                compareTo(other: InstanceType<typeof Version.ComparableVersion>): number;
-                toString(): string;
-            };
+      version: string;
+      revision: number;
+  
+      constructor(version: string, revision?: number);
+  
+      compareTo(other: Version): number;
+  
+      toString(): string;
+  
+      static ComparableVersion: {
+        new (version: string): {
+          value: string;
+          items: number[];
+          parseVersion(version: string): number[];
+          compareTo(
+            other: InstanceType<typeof Version.ComparableVersion>,
+          ): number;
+          toString(): string;
         };
+      };
     }
-
+  
     /**
-     * Object that lets you interact with Conveyor. 
+     * Object that lets you interact with Conveyor.
      * Not all platforms are supported; call `canTriggerUpdateCheckUI` first.
      */
     export class OnlineUpdater {
-        isWindows: boolean;
-        isLinux: boolean;
-        isMac: boolean;
-        updateSiteURL: string;
-        appDir: string;
-
-        /**
-         * Create an OnlineUpdater.
-         * @param {string} updateSiteURL - The base URL of the update 
-         * site (same as `app.site.base-url` in your Conveyor config).
-         */
-        constructor(updateSiteURL: string);
-
-        /**
-         * Get the current version of the application by reading 
-         * the `metadata.properties` file in your update site.
-         * @returns {Version} The current version.
-         */
-        getCurrentVersion(): Version;
-
-        /**
-         * Triggers the update process. If there is an update available 
-         * it will be applied automatically (on Windows) or prompt the user
-         * (on macOS), and the app will be restarted if the update is applied. 
-         * You should ensure you're in a position to restart without the
-         * user losing data before calling this.
-         *
-         * @throws {Error} If update checks are unavailable.
-         */
-        triggerUpdateCheckUI(): void;
-
-        /**
-         * Get the current version from the repository.
-         * @returns {Promise<Version>} A promise that resolves with the 
-         * current version from the repository.
-         */
-        getCurrentVersionFromRepository(): Promise<Version>;
-
-        /**
-         * Check if the update check UI can be triggered.
-         * @returns {string} 'AVAILABLE' if the update check UI can be triggered, 
-         *                   'UNSUPPORTED_PACKAGE_TYPE' if the package type is not supported,
-         *                   'UNIMPLEMENTED' if not implemented for the current platform.
-         */
-        canTriggerUpdateCheckUI(): 'AVAILABLE' | 'UNSUPPORTED_PACKAGE_TYPE' | 'UNIMPLEMENTED';
-
-        private getUpdateExePath(): string;
-
-        private parseProperties(data: string): { [key: string]: string };
+      isWindows: boolean;
+      isLinux: boolean;
+      isMac: boolean;
+      updateSiteURL: string;
+      appDir: string;
+  
+      /**
+       * Create an OnlineUpdater.
+       * @param {string} updateSiteURL - The base URL of the update
+       * site (same as `app.site.base-url` in your Conveyor config).
+       */
+      constructor(updateSiteURL: string);
+  
+      /**
+       * Get the current version of the application by reading
+       * the `metadata.properties` file in your update site.
+       * @returns {Version} The current version.
+       */
+      getCurrentVersion(): Version;
+  
+      /**
+       * Triggers the update process. If there is an update available
+       * it will be applied automatically (on Windows) or prompt the user
+       * (on macOS), and the app will be restarted if the update is applied.
+       * You should ensure you're in a position to restart without the
+       * user losing data before calling this.
+       *
+       * @throws {Error} If update checks are unavailable.
+       */
+      triggerUpdateCheckUI(): void;
+  
+      /**
+       * Get the current version from the repository.
+       * @returns {Promise<Version>} A promise that resolves with the
+       * current version from the repository.
+       */
+      getCurrentVersionFromRepository(): Promise<Version>;
+  
+      /**
+       * Check if the update check UI can be triggered.
+       * @returns {string} 'AVAILABLE' if the update check UI can be triggered,
+       *                   'UNSUPPORTED_PACKAGE_TYPE' if the package type is not supported,
+       *                   'UNIMPLEMENTED' if not implemented for the current platform.
+       */
+      canTriggerUpdateCheckUI():
+        | "AVAILABLE"
+        | "UNSUPPORTED_PACKAGE_TYPE"
+        | "UNIMPLEMENTED";
+  
+      private getUpdateExePath(): string;
+  
+      private parseProperties(data: string): { [key: string]: string };
     }
-
+  
     export const isMacOS: boolean;
-    export const fs: typeof import('fs');
-    export const path: typeof import('path');
-    export const execFile: typeof import('child_process').execFile;
-    export const https: typeof import('https');
-    export const http: typeof import('http');
-}
+    export const fs: typeof import("fs");
+    export const path: typeof import("path");
+    export const execFile: typeof import("child_process").execFile;
+    export const https: typeof import("https");
+    export const http: typeof import("http");
+  }
+  

--- a/electron/conveyor-control/index.d.ts
+++ b/electron/conveyor-control/index.d.ts
@@ -1,0 +1,82 @@
+/**
+ * Type declarations for Electron applications built with Typescript.
+ */
+declare module '@hydraulic/conveyor-control' {
+    export class Version {
+        version: string;
+        revision: number;
+
+        constructor(version: string, revision?: number);
+
+        compareTo(other: Version): number;
+
+        toString(): string;
+
+        static ComparableVersion: {
+            new (version: string): {
+                value: string;
+                items: number[];
+                parseVersion(version: string): number[];
+                compareTo(other: InstanceType<typeof Version.ComparableVersion>): number;
+                toString(): string;
+            };
+        };
+    }
+
+    /**
+     * Object that lets you interact with Conveyor. Not all platforms are supported; call `canTriggerUpdateCheckUI` first.
+     */
+    export class OnlineUpdater {
+        isWindows: boolean;
+        isLinux: boolean;
+        isMac: boolean;
+        updateSiteURL: string;
+        appDir: string;
+
+        /**
+         * Create an OnlineUpdater.
+         * @param {string} updateSiteURL - The base URL of the update site (same as `app.site.base-url` in your Conveyor config).
+         */
+        constructor(updateSiteURL: string);
+
+        /**
+         * Get the current version of the application by reading the `metadata.properties` file in your update site.
+         * @returns {Version} The current version.
+         */
+        getCurrentVersion(): Version;
+
+        /**
+         * Triggers the update process. If there is an update available it will be applied automatically (on Windows) or prompt the user
+         * (on macOS), and the app will be restarted if the update is applied. You should ensure you're in a position to restart without the
+         * user losing data before calling this.
+         *
+         * @throws {Error} If update checks are unavailable.
+         */
+        triggerUpdateCheckUI(): void;
+
+        /**
+         * Get the current version from the repository.
+         * @returns {Promise<Version>} A promise that resolves with the current version from the repository.
+         */
+        getCurrentVersionFromRepository(): Promise<Version>;
+
+        /**
+         * Check if the update check UI can be triggered.
+         * @returns {string} 'AVAILABLE' if the update check UI can be triggered, 
+         *                   'UNSUPPORTED_PACKAGE_TYPE' if the package type is not supported,
+         *                   'UNIMPLEMENTED' if not implemented for the current platform.
+         */
+        canTriggerUpdateCheckUI(): 'AVAILABLE' | 'UNSUPPORTED_PACKAGE_TYPE' | 'UNIMPLEMENTED';
+
+        private getUpdateExePath(): string;
+
+        private parseProperties(data: string): { [key: string]: string };
+    }
+
+    export const isMacOS: boolean;
+    export const fs: typeof import('fs');
+    export const path: typeof import('path');
+    export const execFile: typeof import('child_process').execFile;
+    export const https: typeof import('https');
+    export const http: typeof import('http');
+}

--- a/electron/conveyor-control/index.js
+++ b/electron/conveyor-control/index.js
@@ -160,6 +160,7 @@ class OnlineUpdater {
         } else if (this.isMac) {
             const sparkleFrameworkPath = path.join(this.appDir, '..', 'Frameworks', 'Sparkle.framework');
             if (!fs.existsSync(sparkleFrameworkPath)) {
+                console.error('Failed to locate Sparkle framework at path:', sparkleFrameworkPath);
                 return 'UNSUPPORTED_PACKAGE_TYPE';
             }
             


### PR DESCRIPTION
- Adds type declaration file to `electron/conveyor-control` for typescript based electron applications.
- When calling `canTriggerUpdateCheckUI()`, it would return only `UNSUPPORTED_PACKAGE_TYPE` when the Sparkle framework could not be located. This PR adds an error message for when Sparkle is not located during `canTriggerUpdateCheckUI()`