### PR TITLE
Fix typos in docs for platform specific file-associations

### DIFF
--- a/guidebook/docs/configs/os-integration.md
+++ b/guidebook/docs/configs/os-integration.md
@@ -34,7 +34,7 @@ the `app.file-associations` key, like this:
 app.file-associations = [ .foo ]
 ```
 
-You can even define different file associations for different platforms by using the keys `app.mac.file-assocations`, `app.linux.file-assocations` and `app.windows.file-assocations`. By default, the value of all of those keys is the same as `app.file-associations`.
+You can even define different file associations for different platforms by using the keys `app.mac.file-associations`, `app.linux.file-associations` and `app.windows.file-associations`. By default, the value of all of those keys is the same as `app.file-associations`.
 
 !!! important
     This only registers your app for that file extension. You still have to receive and handle open requests from the


### PR DESCRIPTION
There was a typo in all three platform specific file-associations config keys in the docs. This simply fixes those typos. As the typo was the same for all three platforms, I felt I needed to check it was actually a typo and exporting a project config to json on my computer showed that the docs did really contain a typo. This corrects it to match the actual config keys.